### PR TITLE
The background color could have been changed on data change.

### DIFF
--- a/ngletteravatar.js
+++ b/ngletteravatar.js
@@ -102,7 +102,7 @@ nla.directive('ngLetterAvatar', ['defaultSettings', function (defaultSettings) {
                     }
 
                     if (params.avatarCustomBGColor) {
-                        color = params.avatarCustomBGColor;
+                        color = attrs.avatarcustombgcolor || params.avatarCustomBGColor;
                     }
 
                     var svg = getImgTag(params.width, params.height, color);


### PR DESCRIPTION
In  our app, the `avatarcustombgcolor` is binded to an `color` attribute. Whem the object holding the `data` changes, the `color` changes too.

![](https://media.giphy.com/media/3o7qDQkpHybdS301UY/giphy.gif)
