### PR TITLE
Error: [$compile:missingattr] Attribute 'alphabetcolors' of 'ngLetterAvatar' is non-optional and must be set!

### DIFF
--- a/ngletteravatar.js
+++ b/ngletteravatar.js
@@ -36,7 +36,7 @@ nla.directive('ngLetterAvatar', ['defaultSettings', function (defaultSettings) {
             restrict: 'AE',
             replace: true,
             scope: {
-                alphabetcolors: '=alphabetcolors',
+                alphabetcolors: '=?alphabetcolors',
                 data: '@'
             },
             link: function (scope, element, attrs) {
@@ -235,4 +235,3 @@ function getCharacterObject(character, textColor, fontFamily, fontWeight, fontsi
 
     return textTag;
 }
-


### PR DESCRIPTION
## Problem:
On AngularJS 1.6.6 is possible [set strictComponentBindingsEnabled to true](https://docs.angularjs.org/api/ng/provider/$compileProvider). If we do this, we receive this error on browser console:
```
Error: [$compile:missingattr] Attribute 'alphabetcolors' of 'ngLetterAvatar' is non-optional and must be set!
```

ngletteravatar has default values for `alphabetcolors`, then `alphabetcolors` can be optional.

![screenshot376](https://user-images.githubusercontent.com/938894/31190102-84485f2c-a910-11e7-8b58-11fc7e231e77.png)

alphabetcolors on projects with strictComponentBindingsEnabled(true) fixed

